### PR TITLE
Don't process wem files when importing (don't add them to addressable…

### DIFF
--- a/Editor/WwiseAssetImportProcessors.cs
+++ b/Editor/WwiseAssetImportProcessors.cs
@@ -68,10 +68,11 @@ namespace AK.Wwise.Unity.WwiseAddressables
 					bankAssetsToProcess.Add(item);
 				}
 
-				if (Path.GetExtension(item) == ".wem")
-				{
-					streamingAssetsToProcess.Add(item);
-				}
+				// Intentionally disable WEM processing as we are manually copying into streaming assets
+				// if (Path.GetExtension(item) == ".wem")
+				// {
+				// 	streamingAssetsToProcess.Add(item);
+				// }
 			}
 
 			if (bankAssetsToProcess.Count > 0)

--- a/Runtime/WwiseAddressableSoundBank.cs
+++ b/Runtime/WwiseAddressableSoundBank.cs
@@ -341,6 +341,8 @@ namespace AK.Wwise.Unity.WwiseAddressables
 
 		public void Deserialize()
 		{
+			LocalizedBanks.Clear();
+			LocalizedStreamingMedia.Clear();
 			int idx = 0;
 			foreach (var key in LocalizedBankKeys)
 			{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.audiokinetic.wwise.addressables",
-  "version": "2021.1.6",
+  "version": "2021.1.7",
   "displayName": "Wwise Unity Addressables",
   "description": "Wwise Unity Addressables",
   "unity": "2018.4",


### PR DESCRIPTION
… or to the list of streaming media to copy)

Fixed a bug where modifying sound banks would try to add keys to a dictionary that already had them Update version to 2021.1.7